### PR TITLE
form-elements: add multiple selection support to person-select

### DIFF
--- a/packages/form-elements/README.md
+++ b/packages/form-elements/README.md
@@ -209,6 +209,8 @@ No additional attributes beyond the general ones. The datetime element uses an H
 
 #### Person Select Element (form element)
 
+Lets the user search for persons and select one, or several with `multiple`.
+
 ```html
 <dbp-form-person-select-element
     subscribe="lang auth"
@@ -218,9 +220,35 @@ No additional attributes beyond the general ones. The datetime element uses an H
     required></dbp-form-person-select-element>
 ```
 
+Multiple selection, the value is an array of person identifiers:
+
+```html
+<dbp-form-person-select-element
+    subscribe="lang auth"
+    name="myPeople"
+    label="My people"
+    entry-point-url="https://api.example.com"
+    .value=${['person-identifier-1', 'person-identifier-2']}
+    multiple></dbp-form-person-select-element>
+```
+
 - `entry-point-url`: Base URL of the API entry point
     - Type: String
     - Required for fetching persons
+- `multiple` (optional, default: `false`): Indicates if several persons can be selected
+    - Type: Boolean
+    - Example: `<dbp-form-person-select-element multiple></dbp-form-person-select-element>`
+- `value`: The selected person identifier, or an array of identifiers with `multiple`
+    - Type: String/Array
+    - Identifiers are stored without the `/base/people/` prefix, both notations are accepted as input
+    - Always use the `.value` property for `multiple`, since an array cannot be passed as an attribute
+
+The `change` event contains the selected person identifiers, `values` is always an array:
+
+```js
+// {fieldName: 'myPeople', name: 'myPeople', value: ['person-1'], values: ['person-1']}
+event.detail;
+```
 
 #### Resource Select Element
 
@@ -351,6 +379,7 @@ Displays a datetime value formatted with date, time, and timezone using the `de-
 #### Person Select View
 
 Fetches and displays a person's full name from the API using the stored person identifier.
+With `multiple` all selected persons are resolved and shown one per line.
 
 ```html
 <dbp-form-person-select-view
@@ -360,8 +389,23 @@ Fetches and displays a person's full name from the API using the stored person i
     .value=${'person-identifier'}></dbp-form-person-select-view>
 ```
 
+```html
+<dbp-form-person-select-view
+    subscribe="lang auth"
+    label="My people"
+    entry-point-url="https://api.example.com"
+    .value=${['person-identifier-1', 'person-identifier-2']}
+    multiple></dbp-form-person-select-view>
+```
+
 - `entry-point-url`: Base URL of the API entry point used to resolve the person name
     - Type: String
+- `multiple` (optional, default: `false`): Indicates if several persons should be displayed
+    - Type: Boolean
+    - Without `multiple` only the first person of an array value is shown
+- `value`: The person identifier, or an array of identifiers with `multiple`
+    - Type: String/Array
+    - Always use the `.value` property for `multiple`, since an array cannot be passed as an attribute
 
 #### Resource Select View
 

--- a/packages/form-elements/src/demo.js
+++ b/packages/form-elements/src/demo.js
@@ -34,7 +34,7 @@ export class FormElementsDemo extends LangMixin(
         this.saveButtonEnabled = true;
         this.data = {};
         this.enumItems = {item1: 'Item 1', item2: 'Item 2'};
-        this.isRequired = true;
+        this.isMandatory = false;
         this.entryPointUrl = '';
         // The current selection of the person select elements, so it survives a rerender of the
         // demo, which happens for example when the auth token gets refreshed after a focus change
@@ -67,7 +67,7 @@ export class FormElementsDemo extends LangMixin(
         return {
             ...super.properties,
             saveButtonEnabled: {type: Boolean, attribute: false},
-            isRequired: {type: Boolean, attribute: false},
+            isMandatory: {type: Boolean, attribute: false},
             data: {type: Object, attribute: false},
             entryPointUrl: {type: String, attribute: 'entry-point-url'},
             personValue: {type: String, attribute: false},
@@ -182,13 +182,13 @@ export class FormElementsDemo extends LangMixin(
                     <form>
                         <dbp-form-boolean-element
                             subscribe="lang"
-                            name="isRequired"
-                            label="Fields are required"
-                            description="Disable this to make all fields optional"
+                            name="isMandatory"
+                            label="Fields are mandatory"
+                            description="Enable this to make all fields mandatory"
                             @change=${(e) => {
-                                this.isRequired = e.detail.state;
+                                this.isMandatory = e.detail.state;
                             }}
-                            .state=${this.isRequired}></dbp-form-boolean-element>
+                            .state=${this.isMandatory}></dbp-form-boolean-element>
 
                         <h3 class="subtitle">String elements</h3>
                         <dbp-form-string-element
@@ -196,7 +196,7 @@ export class FormElementsDemo extends LangMixin(
                             name="myComponentString"
                             label="My string"
                             value=${data.myComponentString || ''}
-                            ?required=${this.isRequired}></dbp-form-string-element>
+                            ?required=${this.isMandatory}></dbp-form-string-element>
 
                         <dbp-form-string-element
                             subscribe="lang"
@@ -204,7 +204,7 @@ export class FormElementsDemo extends LangMixin(
                             label="Inline string"
                             layout-type="inline"
                             value=${data.myComponentStringInline || ''}
-                            ?required=${this.isRequired}></dbp-form-string-element>
+                            ?required=${this.isMandatory}></dbp-form-string-element>
 
                         <dbp-form-string-element
                             subscribe="lang"
@@ -212,7 +212,7 @@ export class FormElementsDemo extends LangMixin(
                             label="My long string"
                             value=${data.myComponentLongString || ''}
                             rows="5"
-                            ?required=${this.isRequired}></dbp-form-string-element>
+                            ?required=${this.isMandatory}></dbp-form-string-element>
 
                         <dbp-form-string-element
                             subscribe="lang"
@@ -221,7 +221,7 @@ export class FormElementsDemo extends LangMixin(
                             layout-type="inline"
                             value=${data.myComponentLongStringInline || ''}
                             rows="5"
-                            ?required=${this.isRequired}></dbp-form-string-element>
+                            ?required=${this.isMandatory}></dbp-form-string-element>
 
                         <dbp-form-string-element
                             subscribe="lang"
@@ -229,12 +229,12 @@ export class FormElementsDemo extends LangMixin(
                             label="My special string with slotted description"
                             .customValidator=${(value, evaluationData) => {
                                 // If the value is empty, return an error message with the evaluation data
-                                return value === '' && this.isRequired
+                                return value === '' && this.isMandatory
                                     ? ['evaluationData: ' + JSON.stringify(evaluationData)]
                                     : [];
                             }}
                             value=${data.mySpecialString || ''}
-                            ?required=${this.isRequired}>
+                            ?required=${this.isMandatory}>
                             <div slot="description">
                                 Shows the evaluation data in the error
                                 <b>message</b>
@@ -249,7 +249,7 @@ export class FormElementsDemo extends LangMixin(
                             value=${data.myComponentLongStringWordLimit || ''}
                             rows="5"
                             word-count-limit="10"
-                            ?required=${this.isRequired}></dbp-form-string-element>
+                            ?required=${this.isMandatory}></dbp-form-string-element>
 
                         <h3 class="subtitle">Number elements</h3>
                         <dbp-form-number-element
@@ -257,7 +257,7 @@ export class FormElementsDemo extends LangMixin(
                             name="myComponentNumber"
                             label="My number"
                             value=${data.myComponentNumber || ''}
-                            ?required=${this.isRequired}>
+                            ?required=${this.isMandatory}>
                             <div slot="description">
                                 Number element with a
                                 <b>slot for description</b>
@@ -270,7 +270,7 @@ export class FormElementsDemo extends LangMixin(
                             label="Inline number"
                             layout-type="inline"
                             value=${data.myComponentNumberInline || ''}
-                            ?required=${this.isRequired}></dbp-form-number-element>
+                            ?required=${this.isMandatory}></dbp-form-number-element>
 
                         <dbp-form-number-element
                             subscribe="lang"
@@ -280,7 +280,7 @@ export class FormElementsDemo extends LangMixin(
                             value=${data.myComponentNumberRange || ''}
                             min="1"
                             max="100"
-                            ?required=${this.isRequired}></dbp-form-number-element>
+                            ?required=${this.isMandatory}></dbp-form-number-element>
 
                         <dbp-form-number-element
                             subscribe="lang"
@@ -289,7 +289,7 @@ export class FormElementsDemo extends LangMixin(
                             description="Increments of 0.5"
                             value=${data.myComponentNumberStep || ''}
                             step="0.5"
-                            ?required=${this.isRequired}></dbp-form-number-element>
+                            ?required=${this.isMandatory}></dbp-form-number-element>
 
                         <h3 class="subtitle">Date elements</h3>
                         <dbp-form-date-element
@@ -297,7 +297,7 @@ export class FormElementsDemo extends LangMixin(
                             name="myComponentDate"
                             label="My date"
                             value=${data.myComponentDate || ''}
-                            ?required=${this.isRequired}></dbp-form-date-element>
+                            ?required=${this.isMandatory}></dbp-form-date-element>
 
                         <dbp-form-date-element
                             subscribe="lang"
@@ -305,7 +305,7 @@ export class FormElementsDemo extends LangMixin(
                             label="Inline date"
                             layout-type="inline"
                             value=${data.myComponentDateInline || ''}
-                            ?required=${this.isRequired}></dbp-form-date-element>
+                            ?required=${this.isMandatory}></dbp-form-date-element>
 
                         <dbp-form-datetime-element
                             subscribe="lang"
@@ -319,7 +319,7 @@ export class FormElementsDemo extends LangMixin(
                                     : [];
                             }}
                             value=${data.myComponentDateTime || ''}
-                            ?required=${this.isRequired}></dbp-form-datetime-element>
+                            ?required=${this.isMandatory}></dbp-form-datetime-element>
 
                         <dbp-form-datetime-element
                             subscribe="lang"
@@ -334,7 +334,7 @@ export class FormElementsDemo extends LangMixin(
                                     : [];
                             }}
                             value=${data.myComponentDateTimeInline || ''}
-                            ?required=${this.isRequired}></dbp-form-datetime-element>
+                            ?required=${this.isMandatory}></dbp-form-datetime-element>
 
                         <h3 class="subtitle">Enum elements</h3>
                         <dbp-form-enum-element
@@ -343,7 +343,7 @@ export class FormElementsDemo extends LangMixin(
                             label="My enum"
                             .value=${data.myComponentEnum || ''}
                             .items=${this.enumItems}
-                            ?required=${this.isRequired}></dbp-form-enum-element>
+                            ?required=${this.isMandatory}></dbp-form-enum-element>
 
                         <dbp-form-enum-element
                             subscribe="lang"
@@ -352,7 +352,7 @@ export class FormElementsDemo extends LangMixin(
                             layout-type="inline"
                             .value=${data.myComponentEnumInline || ''}
                             .items=${this.enumItems}
-                            ?required=${this.isRequired}></dbp-form-enum-element>
+                            ?required=${this.isMandatory}></dbp-form-enum-element>
 
                         <dbp-form-enum-element
                             subscribe="lang"
@@ -361,7 +361,7 @@ export class FormElementsDemo extends LangMixin(
                             .value=${data.myComponentMultipleEnum || ''}
                             .items=${this.enumItems}
                             multiple
-                            ?required=${this.isRequired}>
+                            ?required=${this.isMandatory}>
                             <div slot="description">
                                 Enum element with a
                                 <b>slot for description</b>
@@ -375,7 +375,7 @@ export class FormElementsDemo extends LangMixin(
                             .value=${data.myComponentEnumList || ''}
                             .items=${this.enumItems}
                             display-mode="list"
-                            ?required=${this.isRequired}></dbp-form-enum-element>
+                            ?required=${this.isMandatory}></dbp-form-enum-element>
 
                         <dbp-form-enum-element
                             subscribe="lang"
@@ -384,7 +384,7 @@ export class FormElementsDemo extends LangMixin(
                             .items=${this.enumItems}
                             display-mode="list"
                             layout-type="inline"
-                            ?required=${this.isRequired}>
+                            ?required=${this.isMandatory}>
                             <span slot="label">
                                 <em>Inline</em>
                                 enum list
@@ -429,7 +429,7 @@ export class FormElementsDemo extends LangMixin(
                             display-mode="tags"
                             .value=${data.myComponentEnumTags || ''}
                             .items=${this.enumItems}
-                            ?required=${this.isRequired}></dbp-form-enum-element>
+                            ?required=${this.isMandatory}></dbp-form-enum-element>
 
                         <dbp-form-enum-element
                             subscribe="lang"
@@ -440,7 +440,7 @@ export class FormElementsDemo extends LangMixin(
                             .value=${data.myComponentMultipleEnumTags || ''}
                             .items=${this.enumItems}
                             multiple
-                            ?required=${this.isRequired}></dbp-form-enum-element>
+                            ?required=${this.isMandatory}></dbp-form-enum-element>
 
                         <dbp-form-enum-element
                             subscribe="lang"
@@ -451,7 +451,7 @@ export class FormElementsDemo extends LangMixin(
                             .value=${data.myComponentMultipleEnumTagsInline || ''}
                             .items=${this.enumItems}
                             multiple
-                            ?required=${this.isRequired}></dbp-form-enum-element>
+                            ?required=${this.isMandatory}></dbp-form-enum-element>
 
                         <h3 class="subtitle">Boolean elements</h3>
                         <dbp-form-boolean-element
@@ -480,7 +480,7 @@ export class FormElementsDemo extends LangMixin(
                                 this.personValue = e.detail.value;
                             }}
                             entry-point-url="${this.entryPointUrl}"
-                            ?required=${this.isRequired}></dbp-form-person-select-element>
+                            ?required=${this.isMandatory}></dbp-form-person-select-element>
 
                         <dbp-form-person-select-element
                             subscribe="lang"
@@ -493,7 +493,7 @@ export class FormElementsDemo extends LangMixin(
                             }}
                             entry-point-url="${this.entryPointUrl}"
                             multiple
-                            ?required=${this.isRequired}></dbp-form-person-select-element>
+                            ?required=${this.isMandatory}></dbp-form-person-select-element>
 
                         <dbp-form-resource-select-element
                             subscribe="lang"
@@ -503,7 +503,7 @@ export class FormElementsDemo extends LangMixin(
                             .value=${data.myComponentResource || null}
                             entry-point-url="${this.entryPointUrl}"
                             resource-path="/base/organizations"
-                            ?required=${this.isRequired}></dbp-form-resource-select-element>
+                            ?required=${this.isMandatory}></dbp-form-resource-select-element>
 
                         <dbp-form-submission-select-element
                             subscribe="lang"
@@ -515,7 +515,7 @@ export class FormElementsDemo extends LangMixin(
                             entry-point-url="${this.entryPointUrl}"
                             frontend-key="bulletin-company"
                             submission-element-name="name"
-                            ?required=${this.isRequired}></dbp-form-submission-select-element>
+                            ?required=${this.isMandatory}></dbp-form-submission-select-element>
 
                         ${this.getButtonRowHtml()}
                     </form>

--- a/packages/form-elements/src/demo.js
+++ b/packages/form-elements/src/demo.js
@@ -470,7 +470,7 @@ export class FormElementsDemo extends LangMixin(
                             name="myComponentPeople"
                             label="My people (multiple)"
                             .auth=${this.auth ?? {}}
-                            .values=${this.getDemoPeopleValue(data)}
+                            .value=${this.getDemoPeopleValue(data)}
                             entry-point-url="${this.entryPointUrl}"
                             multiple
                             ?required=${this.isRequired}></dbp-form-person-select-element>
@@ -714,7 +714,7 @@ export class FormElementsDemo extends LangMixin(
                         label="My people (multiple)"
                         .auth=${this.auth ?? {}}
                         entry-point-url="${this.entryPointUrl}"
-                        .values=${this.getDemoPeopleValue(data)}
+                        .value=${this.getDemoPeopleValue(data)}
                         multiple></dbp-form-person-select-view>
 
                     <dbp-form-resource-select-view

--- a/packages/form-elements/src/demo.js
+++ b/packages/form-elements/src/demo.js
@@ -141,6 +141,15 @@ export class FormElementsDemo extends LangMixin(
         return personId.startsWith('/base/people/') ? personId : `/base/people/${personId}`;
     }
 
+    getDemoPeopleValue(data) {
+        if (Array.isArray(data.myComponentPeople)) {
+            return data.myComponentPeople;
+        }
+
+        const personId = this.auth?.['person-id'];
+        return personId ? [personId] : [];
+    }
+
     render() {
         return html`
             ${this.renderFormElements()} ${this.renderFormViews()}
@@ -456,6 +465,16 @@ export class FormElementsDemo extends LangMixin(
                             entry-point-url="${this.entryPointUrl}"
                             ?required=${this.isRequired}></dbp-form-person-select-element>
 
+                        <dbp-form-person-select-element
+                            subscribe="lang"
+                            name="myComponentPeople"
+                            label="My people (multiple)"
+                            .auth=${this.auth ?? {}}
+                            .value=${this.getDemoPeopleValue(data)}
+                            entry-point-url="${this.entryPointUrl}"
+                            multiple
+                            ?required=${this.isRequired}></dbp-form-person-select-element>
+
                         <dbp-form-resource-select-element
                             subscribe="lang"
                             name="myComponentResource"
@@ -689,6 +708,14 @@ export class FormElementsDemo extends LangMixin(
                         .auth=${this.auth ?? {}}
                         entry-point-url="${this.entryPointUrl}"
                         .value=${this.getDemoPersonValue(data)}></dbp-form-person-select-view>
+
+                    <dbp-form-person-select-view
+                        subscribe="lang"
+                        label="My people (multiple)"
+                        .auth=${this.auth ?? {}}
+                        entry-point-url="${this.entryPointUrl}"
+                        .value=${this.getDemoPeopleValue(data)}
+                        multiple></dbp-form-person-select-view>
 
                     <dbp-form-resource-select-view
                         subscribe="lang"

--- a/packages/form-elements/src/demo.js
+++ b/packages/form-elements/src/demo.js
@@ -470,7 +470,7 @@ export class FormElementsDemo extends LangMixin(
                             name="myComponentPeople"
                             label="My people (multiple)"
                             .auth=${this.auth ?? {}}
-                            .value=${this.getDemoPeopleValue(data)}
+                            .values=${this.getDemoPeopleValue(data)}
                             entry-point-url="${this.entryPointUrl}"
                             multiple
                             ?required=${this.isRequired}></dbp-form-person-select-element>
@@ -714,7 +714,7 @@ export class FormElementsDemo extends LangMixin(
                         label="My people (multiple)"
                         .auth=${this.auth ?? {}}
                         entry-point-url="${this.entryPointUrl}"
-                        .value=${this.getDemoPeopleValue(data)}
+                        .values=${this.getDemoPeopleValue(data)}
                         multiple></dbp-form-person-select-view>
 
                     <dbp-form-resource-select-view

--- a/packages/form-elements/src/demo.js
+++ b/packages/form-elements/src/demo.js
@@ -36,6 +36,10 @@ export class FormElementsDemo extends LangMixin(
         this.enumItems = {item1: 'Item 1', item2: 'Item 2'};
         this.isRequired = true;
         this.entryPointUrl = '';
+        // The current selection of the person select elements, so it survives a rerender of the
+        // demo, which happens for example when the auth token gets refreshed after a focus change
+        this.personValue = null;
+        this.peopleValue = null;
     }
 
     static get scopedElements() {
@@ -66,6 +70,8 @@ export class FormElementsDemo extends LangMixin(
             isRequired: {type: Boolean, attribute: false},
             data: {type: Object, attribute: false},
             entryPointUrl: {type: String, attribute: 'entry-point-url'},
+            personValue: {type: String, attribute: false},
+            peopleValue: {type: Array, attribute: false},
         };
     }
 
@@ -148,6 +154,14 @@ export class FormElementsDemo extends LangMixin(
 
         const personId = this.auth?.['person-id'];
         return personId ? [personId] : [];
+    }
+
+    getDemoPersonElementValue(data) {
+        return this.personValue ?? this.getDemoPersonValue(data);
+    }
+
+    getDemoPeopleElementValue(data) {
+        return this.peopleValue ?? this.getDemoPeopleValue(data);
     }
 
     render() {
@@ -461,7 +475,10 @@ export class FormElementsDemo extends LangMixin(
                             name="myComponentPerson"
                             label="My person"
                             .auth=${this.auth ?? {}}
-                            .value=${this.getDemoPersonValue(data)}
+                            .value=${this.getDemoPersonElementValue(data)}
+                            @change=${(e) => {
+                                this.personValue = e.detail.value;
+                            }}
                             entry-point-url="${this.entryPointUrl}"
                             ?required=${this.isRequired}></dbp-form-person-select-element>
 
@@ -470,7 +487,10 @@ export class FormElementsDemo extends LangMixin(
                             name="myComponentPeople"
                             label="My people (multiple)"
                             .auth=${this.auth ?? {}}
-                            .value=${this.getDemoPeopleValue(data)}
+                            .value=${this.getDemoPeopleElementValue(data)}
+                            @change=${(e) => {
+                                this.peopleValue = e.detail.values;
+                            }}
                             entry-point-url="${this.entryPointUrl}"
                             multiple
                             ?required=${this.isRequired}></dbp-form-person-select-element>

--- a/packages/form-elements/src/elements/person-select.js
+++ b/packages/form-elements/src/elements/person-select.js
@@ -1,7 +1,6 @@
-import {css, html} from 'lit';
+import {html} from 'lit';
 import {ScopedElementsMixin} from '@dbp-toolkit/common';
 import {DbpBaseElement} from '../base-element.js';
-import {ref, createRef} from 'lit/directives/ref.js';
 import {ResourceSelect} from '@dbp-toolkit/resource-select';
 
 export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) {
@@ -10,18 +9,13 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
         this.entryPointUrl = '';
         this.value = '';
         this.multiple = false;
-        this.selectedPeople = [];
-        this.personSelectRef = createRef();
-        this._loadGeneration = 0;
     }
 
     static get properties() {
         return {
             ...super.properties,
             entryPointUrl: {type: String, attribute: 'entry-point-url'},
-            value: {attribute: 'value'},
             multiple: {type: Boolean},
-            selectedPeople: {state: true},
         };
     }
 
@@ -32,59 +26,7 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
     }
 
     static get styles() {
-        return [
-            ...super.styles,
-            css`
-                .selected-people {
-                    display: flex;
-                    flex-wrap: wrap;
-                    gap: 0.5rem;
-                    margin: 0 0 0.5rem;
-                    padding: 0;
-                    list-style: none;
-                }
-
-                .selected-person {
-                    display: inline-flex;
-                    align-items: center;
-                    gap: 0.35rem;
-                    padding: 0.25rem 0.5rem;
-                    border: 1px solid var(--dbp-border);
-                    border-radius: 0.25rem;
-                    background: var(--dbp-background);
-                    color: var(--dbp-content);
-                }
-
-                .remove-person {
-                    padding: 0;
-                    border: 0;
-                    background: transparent;
-                    color: inherit;
-                    font: inherit;
-                    line-height: 1;
-                    cursor: pointer;
-                }
-
-                .remove-person:disabled {
-                    cursor: default;
-                    opacity: 0.5;
-                }
-            `,
-        ];
-    }
-
-    updated(changedProperties) {
-        super.updated(changedProperties);
-
-        if (
-            this.multiple &&
-            (changedProperties.has('value') ||
-                changedProperties.has('auth') ||
-                changedProperties.has('entryPointUrl') ||
-                changedProperties.has('multiple'))
-        ) {
-            this.loadSelectedPeople();
-        }
+        return [...super.styles];
     }
 
     normalizePersonId(value) {
@@ -95,7 +37,7 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
         return value.startsWith('/base/people/') ? value.replace('/base/people/', '') : value;
     }
 
-    normalizeMultipleValue(value = this.value) {
+    normalizePersonValues(value = this.value) {
         const values = Array.isArray(value) ? value : value ? [value] : [];
 
         return [
@@ -103,12 +45,8 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
         ];
     }
 
-    getPersonSelectValue() {
-        if (this.multiple || !this.value) {
-            return '';
-        }
-
-        return this.value.startsWith('/base/people/') ? this.value : `/base/people/${this.value}`;
+    getPersonSelectValues() {
+        return this.normalizePersonValues().map((personId) => `/base/people/${personId}`);
     }
 
     getPersonSearchQueryParameters(select, searchTerm) {
@@ -128,74 +66,6 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
         return text;
     }
 
-    getPersonName(person, fallback) {
-        const name = [person?.givenName, person?.familyName].filter(Boolean).join(' ').trim();
-        return name || fallback;
-    }
-
-    getPersonUrl(personId) {
-        return new URL(`/base/people/${personId}`, this.entryPointUrl).href;
-    }
-
-    async fetchPerson(personId) {
-        if (!this.entryPointUrl || !this.auth?.token) {
-            return null;
-        }
-
-        const response = await fetch(this.getPersonUrl(personId), {
-            headers: {
-                Accept: 'application/ld+json',
-                Authorization: `Bearer ${this.auth.token}`,
-            },
-        });
-
-        if (!response.ok) {
-            throw new Error(response.statusText);
-        }
-
-        return response.json();
-    }
-
-    async loadSelectedPeople() {
-        const personIds = this.normalizeMultipleValue();
-        const generation = ++this._loadGeneration;
-
-        if (personIds.length === 0) {
-            this.selectedPeople = [];
-            return;
-        }
-
-        if (!this.entryPointUrl || !this.auth?.token) {
-            this.selectedPeople = personIds.map((personId) => ({
-                id: personId,
-                name: personId,
-            }));
-            return;
-        }
-
-        const selectedPeople = await Promise.all(
-            personIds.map(async (personId) => {
-                try {
-                    const person = await this.fetchPerson(personId);
-                    return {
-                        id: personId,
-                        name: this.getPersonName(person, personId),
-                    };
-                } catch (error) {
-                    console.error(error);
-                    return {
-                        id: personId,
-                        name: personId,
-                    };
-                }
-            }),
-        );
-
-        if (generation === this._loadGeneration) {
-            this.selectedPeople = selectedPeople;
-        }
-    }
-
     dispatchValueChange() {
         this.dispatchEvent(
             new CustomEvent('change', {
@@ -203,6 +73,7 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
                     fieldName: this.name,
                     name: this.name,
                     value: this.value,
+                    values: this.normalizePersonValues(),
                 },
                 bubbles: true,
                 composed: true,
@@ -210,94 +81,31 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
         );
     }
 
-    async handlePersonChange(event) {
-        if (!this.multiple) {
-            let value = event.detail?.value ?? '';
-
-            if (typeof value !== 'string') {
-                return;
-            }
-
-            this.value = this.normalizePersonId(value);
-            return;
-        }
-
+    handlePersonChange(event) {
         event.stopPropagation();
 
-        const resourceValue = event.detail?.value;
-        if (typeof resourceValue !== 'string' || resourceValue === '') {
-            return;
-        }
+        const resourceValues = Array.isArray(event.detail?.values)
+            ? event.detail.values
+            : event.detail?.value
+              ? [event.detail.value]
+              : [];
 
-        const personId = this.normalizePersonId(resourceValue);
-        const personIds = this.normalizeMultipleValue();
+        const personIds = this.normalizePersonValues(resourceValues);
 
-        if (!personIds.includes(personId)) {
-            this.value = [...personIds, personId];
-
-            const person = event.detail?.object;
-            this.selectedPeople = [
-                ...this.selectedPeople,
-                {
-                    id: personId,
-                    name: this.getPersonName(person, personId),
-                },
-            ];
-
-            this.dispatchValueChange();
-        }
-
-        await this.personSelectRef.value?.reset();
-    }
-
-    removePerson(personId) {
-        this.value = this.normalizeMultipleValue().filter((value) => value !== personId);
-        this.selectedPeople = this.selectedPeople.filter((person) => person.id !== personId);
+        this.value = this.multiple ? personIds : (personIds[0] ?? '');
         this.dispatchValueChange();
     }
 
     isValueEmpty() {
-        if (this.multiple) {
-            return this.normalizeMultipleValue().length === 0;
-        }
-
-        return !this.value;
-    }
-
-    renderSelectedPeople() {
-        if (this.selectedPeople.length === 0) {
-            return html``;
-        }
-
-        return html`
-            <ul class="selected-people">
-                ${this.selectedPeople.map(
-                    (person) => html`
-                        <li class="selected-person">
-                            <span>${person.name}</span>
-                            <button
-                                class="remove-person"
-                                type="button"
-                                title="Remove ${person.name}"
-                                aria-label="Remove ${person.name}"
-                                ?disabled=${this.disabled}
-                                @click=${() => this.removePerson(person.id)}>
-                                ×
-                            </button>
-                        </li>
-                    `,
-                )}
-            </ul>
-        `;
+        return this.normalizePersonValues().length === 0;
     }
 
     renderInput() {
         return html`
-            ${this.multiple ? this.renderSelectedPeople() : ''}
             <dbp-resource-select
-                ${ref(this.personSelectRef)}
                 .auth=${this.auth ?? {}}
-                .value=${this.getPersonSelectValue()}
+                .values=${this.getPersonSelectValues()}
+                ?multiple=${this.multiple}
                 ?disabled=${this.disabled}
                 lang="${this.lang}"
                 resource-path="/base/people"

--- a/packages/form-elements/src/elements/person-select.js
+++ b/packages/form-elements/src/elements/person-select.js
@@ -36,6 +36,17 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
 
         return value.startsWith('/base/people/') ? value.replace('/base/people/', '') : value;
     }
+    willUpdate(changedProperties) {
+        super.willUpdate(changedProperties);
+
+        if (
+            !this.multiple &&
+            Array.isArray(this.value) &&
+            (changedProperties.has('multiple') || changedProperties.has('value'))
+        ) {
+            this.value = this.normalizePersonValues(this.value)[0] ?? '';
+        }
+    }
 
     normalizePersonValues(value = this.value) {
         const values = Array.isArray(value) ? value : value ? [value] : [];

--- a/packages/form-elements/src/elements/person-select.js
+++ b/packages/form-elements/src/elements/person-select.js
@@ -1,4 +1,4 @@
-import {html} from 'lit';
+import {css, html} from 'lit';
 import {ScopedElementsMixin} from '@dbp-toolkit/common';
 import {DbpBaseElement} from '../base-element.js';
 import {ref, createRef} from 'lit/directives/ref.js';
@@ -9,13 +9,19 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
         super();
         this.entryPointUrl = '';
         this.value = '';
+        this.multiple = false;
+        this.selectedPeople = [];
         this.personSelectRef = createRef();
+        this._loadGeneration = 0;
     }
 
     static get properties() {
         return {
             ...super.properties,
             entryPointUrl: {type: String, attribute: 'entry-point-url'},
+            value: {attribute: 'value'},
+            multiple: {type: Boolean},
+            selectedPeople: {state: true},
         };
     }
 
@@ -25,16 +31,80 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
         };
     }
 
-    firstUpdated() {
-        super.firstUpdated();
+    static get styles() {
+        return [
+            ...super.styles,
+            css`
+                .selected-people {
+                    display: flex;
+                    flex-wrap: wrap;
+                    gap: 0.5rem;
+                    margin: 0 0 0.5rem;
+                    padding: 0;
+                    list-style: none;
+                }
+
+                .selected-person {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 0.35rem;
+                    padding: 0.25rem 0.5rem;
+                    border: 1px solid var(--dbp-border);
+                    border-radius: 0.25rem;
+                    background: var(--dbp-background);
+                    color: var(--dbp-content);
+                }
+
+                .remove-person {
+                    padding: 0;
+                    border: 0;
+                    background: transparent;
+                    color: inherit;
+                    font: inherit;
+                    line-height: 1;
+                    cursor: pointer;
+                }
+
+                .remove-person:disabled {
+                    cursor: default;
+                    opacity: 0.5;
+                }
+            `,
+        ];
     }
 
-    static get styles() {
-        return [...super.styles];
+    updated(changedProperties) {
+        super.updated(changedProperties);
+
+        if (
+            this.multiple &&
+            (changedProperties.has('value') ||
+                changedProperties.has('auth') ||
+                changedProperties.has('entryPointUrl') ||
+                changedProperties.has('multiple'))
+        ) {
+            this.loadSelectedPeople();
+        }
+    }
+
+    normalizePersonId(value) {
+        if (typeof value !== 'string') {
+            return '';
+        }
+
+        return value.startsWith('/base/people/') ? value.replace('/base/people/', '') : value;
+    }
+
+    normalizeMultipleValue(value = this.value) {
+        const values = Array.isArray(value) ? value : value ? [value] : [];
+
+        return [
+            ...new Set(values.map((personId) => this.normalizePersonId(personId)).filter(Boolean)),
+        ];
     }
 
     getPersonSelectValue() {
-        if (!this.value) {
+        if (this.multiple || !this.value) {
             return '';
         }
 
@@ -49,16 +119,181 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
     }
 
     formatPerson(select, person) {
-        let text = person['givenName'] ?? '';
-        if (person['familyName']) {
-            text += ` ${person['familyName']}`;
+        let text = person.givenName ?? '';
+
+        if (person.familyName) {
+            text += ` ${person.familyName}`;
         }
 
         return text;
     }
 
+    getPersonName(person, fallback) {
+        const name = [person?.givenName, person?.familyName].filter(Boolean).join(' ').trim();
+        return name || fallback;
+    }
+
+    getPersonUrl(personId) {
+        return new URL(`/base/people/${personId}`, this.entryPointUrl).href;
+    }
+
+    async fetchPerson(personId) {
+        if (!this.entryPointUrl || !this.auth?.token) {
+            return null;
+        }
+
+        const response = await fetch(this.getPersonUrl(personId), {
+            headers: {
+                Accept: 'application/ld+json',
+                Authorization: `Bearer ${this.auth.token}`,
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(response.statusText);
+        }
+
+        return response.json();
+    }
+
+    async loadSelectedPeople() {
+        const personIds = this.normalizeMultipleValue();
+        const generation = ++this._loadGeneration;
+
+        if (personIds.length === 0) {
+            this.selectedPeople = [];
+            return;
+        }
+
+        if (!this.entryPointUrl || !this.auth?.token) {
+            this.selectedPeople = personIds.map((personId) => ({
+                id: personId,
+                name: personId,
+            }));
+            return;
+        }
+
+        const selectedPeople = await Promise.all(
+            personIds.map(async (personId) => {
+                try {
+                    const person = await this.fetchPerson(personId);
+                    return {
+                        id: personId,
+                        name: this.getPersonName(person, personId),
+                    };
+                } catch (error) {
+                    console.error(error);
+                    return {
+                        id: personId,
+                        name: personId,
+                    };
+                }
+            }),
+        );
+
+        if (generation === this._loadGeneration) {
+            this.selectedPeople = selectedPeople;
+        }
+    }
+
+    dispatchValueChange() {
+        this.dispatchEvent(
+            new CustomEvent('change', {
+                detail: {
+                    fieldName: this.name,
+                    name: this.name,
+                    value: this.value,
+                },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    async handlePersonChange(event) {
+        if (!this.multiple) {
+            let value = event.detail?.value ?? '';
+
+            if (typeof value !== 'string') {
+                return;
+            }
+
+            this.value = this.normalizePersonId(value);
+            return;
+        }
+
+        event.stopPropagation();
+
+        const resourceValue = event.detail?.value;
+        if (typeof resourceValue !== 'string' || resourceValue === '') {
+            return;
+        }
+
+        const personId = this.normalizePersonId(resourceValue);
+        const personIds = this.normalizeMultipleValue();
+
+        if (!personIds.includes(personId)) {
+            this.value = [...personIds, personId];
+
+            const person = event.detail?.object;
+            this.selectedPeople = [
+                ...this.selectedPeople,
+                {
+                    id: personId,
+                    name: this.getPersonName(person, personId),
+                },
+            ];
+
+            this.dispatchValueChange();
+        }
+
+        await this.personSelectRef.value?.reset();
+    }
+
+    removePerson(personId) {
+        this.value = this.normalizeMultipleValue().filter((value) => value !== personId);
+        this.selectedPeople = this.selectedPeople.filter((person) => person.id !== personId);
+        this.dispatchValueChange();
+    }
+
+    isValueEmpty() {
+        if (this.multiple) {
+            return this.normalizeMultipleValue().length === 0;
+        }
+
+        return !this.value;
+    }
+
+    renderSelectedPeople() {
+        if (this.selectedPeople.length === 0) {
+            return html``;
+        }
+
+        return html`
+            <ul class="selected-people">
+                ${this.selectedPeople.map(
+                    (person) => html`
+                        <li class="selected-person">
+                            <span>${person.name}</span>
+                            <button
+                                class="remove-person"
+                                type="button"
+                                title="Remove ${person.name}"
+                                aria-label="Remove ${person.name}"
+                                ?disabled=${this.disabled}
+                                @click=${() => this.removePerson(person.id)}>
+                                ×
+                            </button>
+                        </li>
+                    `,
+                )}
+            </ul>
+        `;
+    }
+
     renderInput() {
         return html`
+            ${this.multiple ? this.renderSelectedPeople() : ''}
             <dbp-resource-select
                 ${ref(this.personSelectRef)}
                 .auth=${this.auth ?? {}}
@@ -69,16 +304,7 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
                 fetch-mode="search"
                 .getSearchQueryParameters=${this.getPersonSearchQueryParameters}
                 .formatResource=${this.formatPerson}
-                @change="${(event) => {
-                    let value = event.detail?.value ?? '';
-                    if (!(value instanceof String) && typeof value !== 'string') {
-                        return;
-                    }
-                    if (value.startsWith('/base/people/')) {
-                        value = value.replace('/base/people/', '');
-                    }
-                    this.value = value;
-                }}"
+                @change=${this.handlePersonChange}
                 entry-point-url="${this.entryPointUrl}"></dbp-resource-select>
         `;
     }

--- a/packages/form-elements/src/elements/person-select.js
+++ b/packages/form-elements/src/elements/person-select.js
@@ -9,12 +9,18 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
         this.entryPointUrl = '';
         this.value = '';
         this.multiple = false;
+        this._personSelectValues = [];
     }
 
     static get properties() {
         return {
             ...super.properties,
             entryPointUrl: {type: String, attribute: 'entry-point-url'},
+            // With "multiple" the value is an array, which must not be reflected: the attribute
+            // would become a comma separated string and the attribute observer of
+            // AdapterLitElement would write that string back into the value, turning the whole
+            // selection into a single unknown person identifier
+            value: {type: String, reflect: false},
             multiple: {type: Boolean},
         };
     }
@@ -57,7 +63,16 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
     }
 
     getPersonSelectValues() {
-        return this.normalizePersonValues().map((personId) => `/base/people/${personId}`);
+        const values = this.normalizePersonValues().map((personId) => `/base/people/${personId}`);
+
+        if (
+            values.length !== this._personSelectValues.length ||
+            values.some((value, index) => value !== this._personSelectValues[index])
+        ) {
+            this._personSelectValues = values;
+        }
+
+        return this._personSelectValues;
     }
 
     getPersonSearchQueryParameters(select, searchTerm) {
@@ -102,6 +117,18 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
               : [];
 
         const personIds = this.normalizePersonValues(resourceValues);
+        const currentPersonIds = this.normalizePersonValues();
+
+        if (
+            personIds.length === currentPersonIds.length &&
+            personIds.every((personId, index) => personId === currentPersonIds[index])
+        ) {
+            return;
+        }
+
+        if (Array.isArray(event.detail?.values)) {
+            this._personSelectValues = event.detail.values;
+        }
 
         this.value = this.multiple ? personIds : (personIds[0] ?? '');
         this.dispatchValueChange();
@@ -115,8 +142,8 @@ export class DbpPersonSelectElement extends ScopedElementsMixin(DbpBaseElement) 
         return html`
             <dbp-resource-select
                 .auth=${this.auth ?? {}}
+                .multiple=${this.multiple}
                 .values=${this.getPersonSelectValues()}
-                ?multiple=${this.multiple}
                 ?disabled=${this.disabled}
                 lang="${this.lang}"
                 resource-path="/base/people"

--- a/packages/form-elements/src/views/person-select.js
+++ b/packages/form-elements/src/views/person-select.js
@@ -7,14 +7,13 @@ export class DbpPersonSelectView extends ScopedElementsMixin(DbpBaseView) {
         super();
         this.name = '';
         this.multiple = false;
-        this._loadGeneration = 0;
+        this._loadRequestId = 0;
     }
 
     static get properties() {
         return {
             ...super.properties,
             entryPointUrl: {type: String, attribute: 'entry-point-url'},
-            value: {attribute: 'value'},
             name: {type: String, attribute: 'name'},
             multiple: {type: Boolean},
         };
@@ -90,7 +89,7 @@ export class DbpPersonSelectView extends ScopedElementsMixin(DbpBaseView) {
 
     async loadPersonNames() {
         const personIds = this.normalizeValues();
-        const generation = ++this._loadGeneration;
+        const loadRequestId = ++this._loadRequestId;
 
         if (personIds.length === 0) {
             this.name = '';
@@ -113,7 +112,7 @@ export class DbpPersonSelectView extends ScopedElementsMixin(DbpBaseView) {
             }),
         );
 
-        if (generation === this._loadGeneration) {
+        if (loadRequestId === this._loadRequestId) {
             this.name = names.join('\n');
         }
     }

--- a/packages/form-elements/src/views/person-select.js
+++ b/packages/form-elements/src/views/person-select.js
@@ -38,11 +38,6 @@ export class DbpPersonSelectView extends ScopedElementsMixin(DbpBaseView) {
         ];
     }
 
-    connectedCallback() {
-        super.connectedCallback();
-        this.loadPersonNames();
-    }
-
     updated(changedProperties) {
         super.updated(changedProperties);
 

--- a/packages/form-elements/src/views/person-select.js
+++ b/packages/form-elements/src/views/person-select.js
@@ -37,7 +37,6 @@ export class DbpPersonSelectView extends ScopedElementsMixin(DbpBaseView) {
             `,
         ];
     }
-
     updated(changedProperties) {
         super.updated(changedProperties);
 
@@ -60,17 +59,11 @@ export class DbpPersonSelectView extends ScopedElementsMixin(DbpBaseView) {
     }
 
     normalizeValues() {
-        const values = this.multiple
-            ? Array.isArray(this.value)
-                ? this.value
-                : this.value
-                  ? [this.value]
-                  : []
-            : this.value
-              ? [this.value]
-              : [];
+        const values = Array.isArray(this.value) ? this.value : this.value ? [this.value] : [];
 
-        return values.map((value) => this.normalizePersonId(value)).filter(Boolean);
+        const selectedValues = this.multiple ? values : values.slice(0, 1);
+
+        return selectedValues.map((value) => this.normalizePersonId(value)).filter(Boolean);
     }
 
     getPersonUrl(personId) {

--- a/packages/form-elements/src/views/person-select.js
+++ b/packages/form-elements/src/views/person-select.js
@@ -5,38 +5,24 @@ import {DbpBaseView} from '../base-view.js';
 export class DbpPersonSelectView extends ScopedElementsMixin(DbpBaseView) {
     constructor() {
         super();
-        this.label = 'A string field';
         this.name = '';
-    }
-
-    async connectedCallback() {
-        super.connectedCallback();
-
-        if (this.value !== '' && this.auth?.token) {
-            this.fetchPersonName(this.value);
-        }
-    }
-
-    updated(changedProperties) {
-        if (changedProperties.get('name')) {
-            this.name = this.name || '';
-        } else if (changedProperties.get('auth') && this.name === '' && this.auth?.token) {
-            this.fetchPersonName(this.value);
-        }
+        this.multiple = false;
+        this._loadGeneration = 0;
     }
 
     static get properties() {
         return {
             ...super.properties,
             entryPointUrl: {type: String, attribute: 'entry-point-url'},
+            value: {attribute: 'value'},
             name: {type: String, attribute: 'name'},
+            multiple: {type: Boolean},
         };
     }
 
     static get styles() {
         return [
             ...super.styles,
-            // language=css
             css`
                 :host([layout-type='inline']) fieldset {
                     display: flex;
@@ -52,36 +38,101 @@ export class DbpPersonSelectView extends ScopedElementsMixin(DbpBaseView) {
         ];
     }
 
+    connectedCallback() {
+        super.connectedCallback();
+        this.loadPersonNames();
+    }
+
+    updated(changedProperties) {
+        super.updated(changedProperties);
+
+        if (
+            changedProperties.has('value') ||
+            changedProperties.has('auth') ||
+            changedProperties.has('entryPointUrl') ||
+            changedProperties.has('multiple')
+        ) {
+            this.loadPersonNames();
+        }
+    }
+
+    normalizePersonId(value) {
+        if (typeof value !== 'string') {
+            return '';
+        }
+
+        return value.startsWith('/base/people/') ? value.replace('/base/people/', '') : value;
+    }
+
+    normalizeValues() {
+        const values = this.multiple
+            ? Array.isArray(this.value)
+                ? this.value
+                : this.value
+                  ? [this.value]
+                  : []
+            : this.value
+              ? [this.value]
+              : [];
+
+        return values.map((value) => this.normalizePersonId(value)).filter(Boolean);
+    }
+
+    getPersonUrl(personId) {
+        return new URL(`/base/people/${personId}`, this.entryPointUrl).href;
+    }
+
+    async fetchPersonName(personId) {
+        const response = await fetch(this.getPersonUrl(personId), {
+            headers: {
+                Accept: 'application/ld+json',
+                Authorization: `Bearer ${this.auth.token}`,
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(response.statusText);
+        }
+
+        const person = await response.json();
+        const name = [person.givenName, person.familyName].filter(Boolean).join(' ').trim();
+
+        return name || personId;
+    }
+
+    async loadPersonNames() {
+        const personIds = this.normalizeValues();
+        const generation = ++this._loadGeneration;
+
+        if (personIds.length === 0) {
+            this.name = '';
+            return;
+        }
+
+        if (!this.entryPointUrl || !this.auth?.token) {
+            this.name = personIds.join('\n');
+            return;
+        }
+
+        const names = await Promise.all(
+            personIds.map(async (personId) => {
+                try {
+                    return await this.fetchPersonName(personId);
+                } catch (error) {
+                    console.error(error);
+                    return personId;
+                }
+            }),
+        );
+
+        if (generation === this._loadGeneration) {
+            this.name = names.join('\n');
+        }
+    }
+
     renderValue() {
         return html`
             <div style="white-space: pre-line">${this.name}</div>
         `;
-    }
-
-    fetchPersonName(value) {
-        if (!value || !this.entryPointUrl || !this.auth?.token) {
-            return;
-        }
-
-        fetch(
-            value.startsWith('/base/people/')
-                ? this.entryPointUrl + value
-                : this.entryPointUrl + '/base/people/' + value,
-            {
-                method: 'GET',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${this.auth.token}`,
-                },
-            },
-        )
-            .then((response) => response.json())
-            .then((data) => {
-                if (data.givenName && data.familyName) {
-                    this.name = data.givenName + ' ' + data.familyName || '';
-                } else {
-                    this.name = value;
-                }
-            });
     }
 }

--- a/packages/form-elements/test/unit.js
+++ b/packages/form-elements/test/unit.js
@@ -8,6 +8,7 @@ import '../src/build/date';
 import '../src/build/enum';
 import '../src/demo';
 import {DbpPersonSelectElement} from '../src/elements/person-select.js';
+import {DbpPersonSelectView} from '../src/views/person-select.js';
 
 const personSelectTestTag = 'test-dbp-form-person-select-element';
 
@@ -15,6 +16,14 @@ class TestDbpPersonSelectElement extends DbpPersonSelectElement {}
 
 if (!customElements.get(personSelectTestTag)) {
     customElements.define(personSelectTestTag, TestDbpPersonSelectElement);
+}
+
+const personSelectViewTestTag = 'test-dbp-form-person-select-view';
+
+class TestDbpPersonSelectView extends DbpPersonSelectView {}
+
+if (!customElements.get(personSelectViewTestTag)) {
+    customElements.define(personSelectViewTestTag, TestDbpPersonSelectView);
 }
 suite('dbp-form-boolean-element', () => {
     let node;
@@ -204,15 +213,46 @@ suite('dbp-form-person-select-element', () => {
         assert.deepEqual(resourceSelect.values, ['/base/people/person-1', '/base/people/person-2']);
     });
 
-    test('keeps only the first value in single mode', async () => {
-        node.multiple = false;
+    test('normalizes the public value when switching to single mode', async () => {
+        node.multiple = true;
         node.value = ['person-1', 'person-2'];
+
+        await node.updateComplete;
+
+        node.multiple = false;
 
         await node.updateComplete;
 
         const resourceSelect = node.shadowRoot.querySelector('dbp-resource-select');
 
+        assert.equal(node.value, 'person-1');
         assert.isFalse(resourceSelect.multiple);
         assert.deepEqual(resourceSelect.values, ['/base/people/person-1']);
+    });
+    suite('dbp-form-person-select-view', () => {
+        let node;
+
+        setup(async () => {
+            node = document.createElement(personSelectViewTestTag);
+            document.body.appendChild(node);
+            await node.updateComplete;
+        });
+
+        teardown(() => {
+            node.remove();
+        });
+
+        test('keeps the first person when switching to single mode', async () => {
+            node.multiple = true;
+            node.value = ['person-1', 'person-2'];
+
+            await node.updateComplete;
+
+            node.multiple = false;
+            await node.loadPersonNames();
+
+            assert.deepEqual(node.normalizeValues(), ['person-1']);
+            assert.equal(node.name, 'person-1');
+        });
     });
 });

--- a/packages/form-elements/test/unit.js
+++ b/packages/form-elements/test/unit.js
@@ -1,4 +1,5 @@
 import {assert} from 'chai';
+import $ from 'jquery';
 
 import '../src/build/boolean';
 import '../src/build/date';
@@ -24,6 +25,41 @@ class TestDbpPersonSelectView extends DbpPersonSelectView {}
 
 if (!customElements.get(personSelectViewTestTag)) {
     customElements.define(personSelectViewTestTag, TestDbpPersonSelectView);
+}
+
+/**
+ * Waits until the callback returns a truthy value, so we don't have to guess how long the
+ * async select2 setup takes.
+ * @param {() => (Element|null)} callback - Called repeatedly until it returns an element
+ * @param {number} [timeout] - How long to wait in milliseconds
+ * @returns {Promise<Element|null>} The element, or null on timeout
+ */
+async function waitFor(callback, timeout = 500) {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+        const value = callback();
+        if (value) {
+            return value;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    return null;
+}
+
+/**
+ * Simulates a person being picked in the select2 dropdown of the nested resource select.
+ * @param {Element} resourceSelect - The nested dbp-resource-select
+ * @param {string} personId - The person identifier to select
+ */
+function selectPerson(resourceSelect, personId) {
+    const id = `/base/people/${personId}`;
+    const resource = {'@id': id, givenName: 'Person', familyName: personId};
+
+    $(resourceSelect.renderRoot.querySelector('#' + resourceSelect._selectId)).trigger({
+        type: 'select2:select',
+        params: {data: {id: id, text: `Person ${personId}`, resource: resource}},
+    });
 }
 suite('dbp-form-boolean-element', () => {
     let node;
@@ -131,6 +167,42 @@ suite('dbp-form-elements-demo', () => {
     test('should render', () => {
         assert.isNotNull(node.shadowRoot);
     });
+
+    test('starts the multiple person demo with the current person selected', () => {
+        node.auth = {'person-id': 'person-1'};
+
+        assert.deepEqual(node.getDemoPeopleValue({}), ['person-1']);
+        assert.deepEqual(node.getDemoPeopleValue({myComponentPeople: ['person-2']}), ['person-2']);
+    });
+
+    test('keeps the selected people while the demo rerenders', async () => {
+        node.auth = {'person-id': 'person-1'};
+        await node.updateComplete;
+
+        const personSelect = node.shadowRoot.querySelector(
+            'dbp-form-person-select-element[name="myComponentPeople"]',
+        );
+        assert.isNotNull(personSelect);
+
+        // Wait until the nested selector applied the initial selection
+        const resourceSelect = personSelect.shadowRoot.querySelector('dbp-resource-select');
+        await waitFor(() => (resourceSelect.values.length ? resourceSelect : null));
+
+        personSelect.handlePersonChange(
+            new CustomEvent('change', {
+                detail: {values: ['/base/people/person-1', '/base/people/person-2']},
+            }),
+        );
+        await node.updateComplete;
+        await personSelect.updateComplete;
+
+        // A rerender happens for example when the auth token gets refreshed after a focus change
+        node.requestUpdate();
+        await node.updateComplete;
+        await personSelect.updateComplete;
+
+        assert.deepEqual(personSelect.value, ['person-1', 'person-2']);
+    });
 });
 suite('dbp-form-person-select-element', () => {
     let node;
@@ -177,6 +249,7 @@ suite('dbp-form-person-select-element', () => {
         await node.updateComplete;
 
         let eventDetail = null;
+        const resourceValues = ['/base/people/person-1', '/base/people/person-2'];
 
         node.addEventListener('change', (event) => {
             eventDetail = event.detail;
@@ -185,10 +258,12 @@ suite('dbp-form-person-select-element', () => {
         node.handlePersonChange(
             new CustomEvent('change', {
                 detail: {
-                    values: ['/base/people/person-1', '/base/people/person-2'],
+                    values: resourceValues,
                 },
             }),
         );
+
+        assert.strictEqual(node.getPersonSelectValues(), resourceValues);
 
         await node.updateComplete;
 
@@ -201,16 +276,45 @@ suite('dbp-form-person-select-element', () => {
         });
     });
 
-    test('passes multiple values to the resource selector', async () => {
+    test('ignores repeated multiple selection events with unchanged values', async () => {
+        node.multiple = true;
+        await node.updateComplete;
+
+        let changeCount = 0;
+        node.addEventListener('change', () => {
+            changeCount += 1;
+        });
+
+        const event = () =>
+            new CustomEvent('change', {
+                detail: {
+                    values: ['/base/people/person-1', '/base/people/person-2'],
+                },
+            });
+
+        node.handlePersonChange(event());
+        const selectedPeople = node.value;
+        node.handlePersonChange(event());
+
+        assert.equal(changeCount, 1);
+        assert.strictEqual(node.value, selectedPeople);
+    });
+
+    test('passes stable multiple values to the resource selector', async () => {
         node.multiple = true;
         node.value = ['person-1', 'person-2'];
 
         await node.updateComplete;
 
         const resourceSelect = node.shadowRoot.querySelector('dbp-resource-select');
+        const resourceValues = resourceSelect.values;
+
+        node.requestUpdate();
+        await node.updateComplete;
 
         assert.isTrue(resourceSelect.multiple);
         assert.deepEqual(resourceSelect.values, ['/base/people/person-1', '/base/people/person-2']);
+        assert.strictEqual(resourceSelect.values, resourceValues);
     });
 
     test('normalizes the public value when switching to single mode', async () => {
@@ -229,6 +333,60 @@ suite('dbp-form-person-select-element', () => {
         assert.isFalse(resourceSelect.multiple);
         assert.deepEqual(resourceSelect.values, ['/base/people/person-1']);
     });
+    test('keeps earlier people selected when picking another one', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = async (url) => {
+            const id = String(url).replace(/^.*\/base\/people\//, '');
+            return new Response(
+                JSON.stringify({
+                    '@id': `/base/people/${id}`,
+                    givenName: 'Person',
+                    familyName: id,
+                }),
+                {status: 200, headers: {'Content-Type': 'application/ld+json'}},
+            );
+        };
+
+        try {
+            node.multiple = true;
+            node.entryPointUrl = 'https://api.example.com';
+            node.auth = {'login-status': 'logged-in', token: 'token'};
+
+            const resourceSelect = node.shadowRoot.querySelector('dbp-resource-select');
+            const control = await waitFor(() =>
+                resourceSelect.renderRoot.querySelector('.select2-selection--multiple'),
+            );
+            assert.isNotNull(control, 'the multiple selector should be initialized');
+
+            // Rebuilding select2 while people get picked would drop the visible selection
+            let rebuildCount = 0;
+            const clearSelect2 = resourceSelect._clearSelect2.bind(resourceSelect);
+            resourceSelect._clearSelect2 = () => {
+                rebuildCount += 1;
+                return clearSelect2();
+            };
+
+            selectPerson(resourceSelect, 'person-1');
+            await node.updateComplete;
+            await resourceSelect.updateComplete;
+
+            assert.deepEqual(node.value, ['person-1']);
+
+            selectPerson(resourceSelect, 'person-2');
+            await node.updateComplete;
+            await resourceSelect.updateComplete;
+
+            assert.deepEqual(node.value, ['person-1', 'person-2']);
+            assert.deepEqual(resourceSelect.values, [
+                '/base/people/person-1',
+                '/base/people/person-2',
+            ]);
+            assert.equal(rebuildCount, 0, 'the selector must not be rebuilt while selecting');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
     suite('dbp-form-person-select-view', () => {
         let node;
 

--- a/packages/form-elements/test/unit.js
+++ b/packages/form-elements/test/unit.js
@@ -7,7 +7,15 @@ import '../src/build/datetime';
 import '../src/build/date';
 import '../src/build/enum';
 import '../src/demo';
+import {DbpPersonSelectElement} from '../src/elements/person-select.js';
 
+const personSelectTestTag = 'test-dbp-form-person-select-element';
+
+class TestDbpPersonSelectElement extends DbpPersonSelectElement {}
+
+if (!customElements.get(personSelectTestTag)) {
+    customElements.define(personSelectTestTag, TestDbpPersonSelectElement);
+}
 suite('dbp-form-boolean-element', () => {
     let node;
 
@@ -113,5 +121,98 @@ suite('dbp-form-elements-demo', () => {
 
     test('should render', () => {
         assert.isNotNull(node.shadowRoot);
+    });
+});
+suite('dbp-form-person-select-element', () => {
+    let node;
+
+    setup(async () => {
+        node = document.createElement(personSelectTestTag);
+        node.name = 'applicant';
+        document.body.appendChild(node);
+        await node.updateComplete;
+    });
+
+    teardown(() => {
+        node.remove();
+    });
+
+    test('dispatches a normalized single value', async () => {
+        let eventDetail = null;
+
+        node.addEventListener('change', (event) => {
+            eventDetail = event.detail;
+        });
+
+        node.handlePersonChange(
+            new CustomEvent('change', {
+                detail: {
+                    values: ['/base/people/person-1'],
+                },
+            }),
+        );
+
+        await node.updateComplete;
+
+        assert.equal(node.value, 'person-1');
+        assert.deepEqual(eventDetail, {
+            fieldName: 'applicant',
+            name: 'applicant',
+            value: 'person-1',
+            values: ['person-1'],
+        });
+    });
+
+    test('dispatches normalized multiple values', async () => {
+        node.multiple = true;
+        await node.updateComplete;
+
+        let eventDetail = null;
+
+        node.addEventListener('change', (event) => {
+            eventDetail = event.detail;
+        });
+
+        node.handlePersonChange(
+            new CustomEvent('change', {
+                detail: {
+                    values: ['/base/people/person-1', '/base/people/person-2'],
+                },
+            }),
+        );
+
+        await node.updateComplete;
+
+        assert.deepEqual(node.value, ['person-1', 'person-2']);
+        assert.deepEqual(eventDetail, {
+            fieldName: 'applicant',
+            name: 'applicant',
+            value: ['person-1', 'person-2'],
+            values: ['person-1', 'person-2'],
+        });
+    });
+
+    test('passes multiple values to the resource selector', async () => {
+        node.multiple = true;
+        node.value = ['person-1', 'person-2'];
+
+        await node.updateComplete;
+
+        const resourceSelect = node.shadowRoot.querySelector('dbp-resource-select');
+
+        assert.isTrue(resourceSelect.multiple);
+        assert.deepEqual(resourceSelect.values, ['/base/people/person-1', '/base/people/person-2']);
+    });
+
+    test('keeps only the first value in single mode', async () => {
+        node.multiple = false;
+        node.value = ['person-1', 'person-2'];
+
+        await node.updateComplete;
+
+        const resourceSelect = node.shadowRoot.querySelector('dbp-resource-select');
+
+        assert.isFalse(resourceSelect.multiple);
+        assert.deepEqual(resourceSelect.values, ['/base/people/person-1']);
     });
 });

--- a/packages/resource-select/src/resource-select.js
+++ b/packages/resource-select/src/resource-select.js
@@ -461,10 +461,14 @@ export class ResourceSelect extends LangMixin(
             return;
         }
 
-        const $select = this._getSelect2();
         const results = await Promise.allSettled(
             this.values.map((value) => this._fetchResource(value)),
         );
+
+        // Another update may have added the entries already while we were fetching, so we
+        // start from scratch instead of showing the same entry multiple times
+        const $select = this._getSelect2();
+        $select.empty();
 
         /** @type {string[]} */
         const ids = [];

--- a/packages/resource-select/test/unit.js
+++ b/packages/resource-select/test/unit.js
@@ -276,6 +276,40 @@ suite('dbp-resource-select basics', () => {
         assert.equal(node.value, null);
     });
 
+    test('should not duplicate the selected entries on overlapping updates', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = async (url) => {
+            const id = String(url).replace(/^.*(\/base\/organizations\/[^?]*).*$/, '$1');
+            return new Response(JSON.stringify({'@id': id, name: 'Alpha'}), {
+                status: 200,
+                headers: {'Content-Type': 'application/ld+json'},
+            });
+        };
+
+        try {
+            node.multiple = true;
+            node.fetchMode = 'search';
+            node.entryPointUrl = 'https://api.example.com';
+            node.auth = {'login-status': 'logged-in', token: 'token'};
+            node.values = ['/base/organizations/1'];
+            await node.updateComplete;
+
+            // Several properties arriving after each other start overlapping updates, which
+            // must not add the same entry to the selection more than once
+            await Promise.all([
+                node._updateSearchValue(),
+                node._updateSearchValue(),
+                node._updateSearchValue(),
+            ]);
+
+            const options = node.shadowRoot.querySelectorAll('#' + node._selectId + ' option');
+            assert.equal(options.length, 1);
+            assert.deepEqual(node.values, ['/base/organizations/1']);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
     test('should not refresh select2 when auth token refreshes', async () => {
         let updateCount = 0;
         node._updateAll = () => {


### PR DESCRIPTION
## summary

- add multiple-selection support to the person select form element
- reuse the multiple-selection mode provided by `dbp-resource-select`
- preserve the existing single-selection behavior
- support person identifiers as single values and arrays
- emit normalized change events including the field name
- resolve and display multiple person names in the read-only view
- avoid duplicate initial person lookups
- add unit tests for single and multiple selection behavior

## testing

validated the latest changes locally:

- `npm run check --workspace=@dbp-toolkit/form-elements` passed
- Firefox: 15 tests passed
- Chromium: 15 tests passed